### PR TITLE
Removed unused namespace

### DIFF
--- a/ArxLibertatisLevelEditor/Assets/OutlineEffect/OutlineEffect/OutlineEffect.cs
+++ b/ArxLibertatisLevelEditor/Assets/OutlineEffect/OutlineEffect/OutlineEffect.cs
@@ -25,7 +25,6 @@
 using UnityEngine;
 using System.Collections.Generic;
 using UnityEngine.Rendering;
-using UnityEngine.VR;
 
 namespace cakeslice
 {


### PR DESCRIPTION
This line caused compilation error in Unity 2020.2